### PR TITLE
use set for deck_names container to prevent the test from being nonde…

### DIFF
--- a/tests/test_decks.py
+++ b/tests/test_decks.py
@@ -11,7 +11,7 @@ def test_decks():
     with AnkiSimple() as a:
         assert a.col.decks.count() == 2
         assert a.col.decks.current()['name'] == 'NewDeck'
-        assert list(a.deck_names) == ['Default', 'NewDeck']
+        assert set(a.deck_names) == {'Default', 'NewDeck'}
 
         notes = a.add_notes_from_file(testDir + '/' + 'data/deck.md')
 


### PR DESCRIPTION
When I ran `pytest` I noticed that the tests would pass sometimes and fail others. This turned out to be because the order of `a.deck_names` would change from one run to the next:

```

[ckp95@ckp95-desktop apy]$ pytest
================================== test session starts ==================================
platform linux -- Python 3.8.3, pytest-5.4.3, py-1.8.1, pluggy-0.13.1
rootdir: /home/ckp95/Documents/apy, inifile: pytest.ini
collected 7 items                                                                       

tests/test_basics.py ...                                                          [ 42%]
tests/test_batch_edit.py .                                                        [ 57%]
tests/test_decks.py .                                                             [ 71%]
tests/test_errors.py .                                                            [ 85%]
tests/test_models.py .                                                            [100%]

=================================== 7 passed in 0.76s ===================================
[ckp95@ckp95-desktop apy]$ pytest
================================== test session starts ==================================
platform linux -- Python 3.8.3, pytest-5.4.3, py-1.8.1, pluggy-0.13.1
rootdir: /home/ckp95/Documents/apy, inifile: pytest.ini
collected 7 items                                                                       

tests/test_basics.py ...                                                          [ 42%]
tests/test_batch_edit.py .                                                        [ 57%]
tests/test_decks.py F                                                             [ 71%]
tests/test_errors.py .                                                            [ 85%]
tests/test_models.py .                                                            [100%]

======================================= FAILURES ========================================
______________________________________ test_decks _______________________________________

    def test_decks():
        """Test empty collection"""
        with AnkiSimple() as a:
            assert a.col.decks.count() == 2
            assert a.col.decks.current()['name'] == 'NewDeck'
>           assert list(a.deck_names) == ['Default', 'NewDeck']
E           AssertionError: assert ['NewDeck', 'Default'] == ['Default', 'NewDeck']
E             At index 0 diff: 'NewDeck' != 'Default'
E             Use -v to get the full diff

tests/test_decks.py:14: AssertionError
================================ short test summary info ================================
FAILED tests/test_decks.py::test_decks - AssertionError: assert ['NewDeck', 'Default']...
============================== 1 failed, 6 passed in 0.88s ==============================
```

I couldn't figure out why this would be -- I looked around in the anki source (`decks.py`) and it seems to be stored as a dict, not a set, and dicts have been guaranteed to preserve order since Python 3.7.

Regardless, I changed `list` to `set` so that the order doesn't matter for the test, now it passes all the time.