### PR TITLE
Automatically look in default base directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ databases and code:
 * [AnkiDroid: Database
   Structure](https://github.com/ankidroid/Anki-Android/wiki/Database-Structure)
 * [AnkiConnect.py](https://github.com/FooSoft/anki-connect/blob/master/AnkiConnect.py)
-* [The Anki Manual](https://apps.ankiweb.net/docs/manual.html)
+* [The Anki Manual](https://docs.ankiweb.net)
 
 ## Alternatives
 

--- a/apy/cli.py
+++ b/apy/cli.py
@@ -25,7 +25,7 @@ def main(ctx, base, profile, version):
     ANKI_BASE. This should point to the base directory where Anki stores its
     database and related files. See the Anki documentation for information
     about where this is located on different systems
-    (https://apps.ankiweb.net/docs/manual.html#file-locations).
+    (https://docs.ankiweb.net/files.html#file-locations).
 
     A few sub commands will open an editor for input. Vim is used by default.
     The input is parsed when one saves and quits. To abort, one should exit the

--- a/apy/config.py
+++ b/apy/config.py
@@ -35,12 +35,28 @@ if 'default' not in cfg['presets']:
     }
 
 
-# If base not defined: Look in environment variables
-if cfg['base'] is None:
-    for var in ['APY_BASE', 'ANKI_BASE']:
-        if var in os.environ:
-            cfg['base'] = os.environ[var]
-            break
+def get_base_path():
+    # If base not defined: Look in environment variables
+    if path := os.environ.get("APY_BASE"):
+        return path
+
+    if path := os.environ.get("ANKI_BASE"):
+        return path
+
+    # Otherwise look in usual paths:
+    # https://docs.ankiweb.net/files.html#file-locations
+    if (path := Path.home() / ".local/share/Anki2").exists():
+        return str(path)
+
+    if xdg_data_home := os.environ.get("XDG_DATA_HOME"):
+        if (path := Path(xdg_data_home) / "Anki2").exists():
+            return str(path)
+
+    return None
+
+
+if cfg["base"] is None:
+    cfg["base"] = get_base_path()
 
 
 # Ensure base path is a proper absolute path


### PR DESCRIPTION
To find the base directory, it looks in the following places in order:

- the `-b` commandline parameter
- environmental variable `APY_BASE`
- environmental variable `ANKI_BASE`
- `$HOME/.local/share/Anki2`
- `$XDG_DATA_HOME/Anki2`

The last two are new. This means you don't have to bother to pass in the command line flag or edit the config file, in most cases.

I also updated the links to the Anki docs.