### PR TITLE
chore: add incremental type checking with mypy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,8 @@ jobs:
         run: poetry install --no-interaction --no-root
       - name: Run black
         run: poetry run black --check .
+      - name: Run mypy
+        run: poetry run mypy src
 
   test:
     needs: lint

--- a/README.md
+++ b/README.md
@@ -376,3 +376,9 @@ To format the code, run:
 ```sh
 poetry run black .
 ```
+
+To type-check the code, run:
+
+```sh
+poetry run mypy src
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ pylint = "^2.17.4"
 pyqtwebengine = "^5.15.6"
 bump2version = "^1.0.1"
 black = "^23.3.0"
+mypy = "^1.3.0"
+types-beautifulsoup4 = "^4.12.0.5"
+types-markdown = "^3.4.2.9"
 
 [tool.pytest]
 filterwarnings = ["ignore::DeprecationWarning:html5lib.*:"]
@@ -48,3 +51,22 @@ disable = [
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.mypy]
+exclude = ".venv"
+strict = true
+
+# We're currently adding incremental type checking to the codebase, one file at
+# a time. This means that we need to ignore errors in files that have not yet
+# been type checked. Once a file has been type checked, it should be removed
+# from the list below.
+[[tool.mypy.overrides]]
+module = [
+    "apy.anki",
+    "apy.cli",
+    "apy.convert",
+    "apy.__init__",
+    "apy.note",
+    "apy.utilities",
+]
+ignore_errors = true

--- a/src/apy/config.py
+++ b/src/apy/config.py
@@ -2,15 +2,16 @@
 import json
 import os
 from pathlib import Path
+from typing import Optional, Any
 
 
-def get_base_path():
+def get_base_path() -> Optional[str]:
     # If base_path not defined: Look in environment variables
-    if path := os.environ.get("APY_BASE"):
-        return path
+    if path_as_str := os.environ.get("APY_BASE"):
+        return path_as_str
 
-    if path := os.environ.get("ANKI_BASE"):
-        return path
+    if path_as_str := os.environ.get("ANKI_BASE"):
+        return path_as_str
 
     # Otherwise look in usual paths:
     # https://docs.ankiweb.net/files.html#file-locations
@@ -34,21 +35,20 @@ else:
     cfg = {}
 
 
+CFG_DEFAULT_VALUES: dict[str, Any] = {
+    "base_path": None,
+    "img_viewers": {
+        "svg": ["display", "-density", "300"],
+    },
+    "img_viewers_default": ["feh"],
+    "markdown_models": ["Basic"],
+    "presets": {},
+    "profile_name": None,
+    "query": "tag:marked OR -flag:0",
+}
+
 # Ensure that cfg has required keys
-for required, default in [
-    ("base_path", None),
-    (
-        "img_viewers",
-        {
-            "svg": ["display", "-density", "300"],
-        },
-    ),
-    ("img_viewers_default", ["feh"]),
-    ("markdown_models", ["Basic"]),
-    ("presets", {}),
-    ("profile_name", None),
-    ("query", "tag:marked OR -flag:0"),
-]:
+for required, default in CFG_DEFAULT_VALUES.items():
     if required not in cfg:
         cfg[required] = default
 


### PR DESCRIPTION
The PR sets up mypy to be adopted incrementally in the code base.

The idea is: we make mypy ignore all files. We then annotate one file at a time. As we annotate files, we remove them from being ignored by mypy.

I have type-annotated the `apy.config` module while ignoring all other modules.

The workflow for annotating an extra file is:

1. Remove the file from the ignore list in `pyproject.toml`
2. Run `mypy src` to identify the violations
3. Fix the violations
4. Be happy and type-safe

Do you think this works for you, @lervag?

If you're happy with the approach, I will annotate/fix other files and add a type-check step to the Github Action.

Looking forward to your feedback.

Greetings from Hamburg!