### PR TITLE
Remove deprecated stuff in __init__.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Anki](https://apps.ankiweb.net/index.html) is a flash card program which makes
 remembering things easy. `apy` is a Python script for easily adding cards to
-Anki.
+Anki. It does not require Anki to be running at the same time.
 
 ### Important
 
@@ -32,10 +32,10 @@ Anki.
 pip install git+https://github.com/lervag/apy
 ```
 
-**However**, notice that installing Python packages outside virtual
-environments is not recommended, even at the user level! If you do this, then
-be aware that you may experience issues due to conflicts with other
-packages/tools installed in the same manner.
+**However**, note that installing Python packages outside [virtual
+environments](https://docs.python.org/3/library/venv.html) is not recommended,
+even at the user level! If you do this, then be aware that you may experience
+issues due to conflicts with other packages/tools installed in the same manner.
 
 Instead, the best way to install `apy` for normal usage is with
 [`pipx`](https://pypa.github.io/pipx/). This will ensure `apy` doesn't

--- a/src/apy/__init__.py
+++ b/src/apy/__init__.py
@@ -1,6 +1,5 @@
 """Package for interfacing and manipulating Anki decks"""
 import os
-from importlib.util import find_spec
 from importlib.metadata import version
 
 __version__ = version("apy")
@@ -10,14 +9,3 @@ __version__ = version("apy")
 # sets it to debug
 if "RUST_LOG" not in os.environ:
     os.environ["RUST_LOG"] = "warn,anki::media=info,anki::sync=info,anki::dbcheck=info"
-
-# Avoid unnecessary Qt5 message
-if "DISABLE_QT5_COMPAT" not in os.environ:
-    os.environ["DISABLE_QT5_COMPAT"] = "1"
-
-if find_spec("anki") is None:
-    import sys
-
-    _path = os.environ.get("APY_ANKI_PATH", "/usr/share/anki")
-    if os.path.isdir(_path):
-        sys.path.append(_path)


### PR DESCRIPTION
We don't need this anymore now that the aqt dependency is gone and we're not relying on the system anki install.

Also I thought the big unique selling point should be mentioned in the first paragraph of the readme :)