### PR TITLE
added basic edit functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tests/data
 .vimspector.json
 uv.lock
 .python-version
+venv/

--- a/src/apyanki/cli.py
+++ b/src/apyanki/cli.py
@@ -442,6 +442,7 @@ def review(query: str, check_markdown_consistency: bool, cmc_range: int) -> None
             else:
                 i += 1
 
+
 @main.command()
 @click.argument("query", nargs=-1, required=True)
 @click.option(
@@ -486,19 +487,54 @@ def edit(query: str, force_multiple: bool) -> None:
         # Handle multiple matches
         if len(notes) > 1 and not force_multiple:
             console.print(f"Query matched {len(notes)} notes.")
-            # for i, note in enumerate(notes[:5]):
-            # maybe we can show the first 5 matches?
 
-            console.print("Use --force-multiple to edit them all, or refine your query.")
+            # Show preview of the first 5 matching notes
+            console.print("\nFirst few matching notes:")
+            for i, note in enumerate(notes[:5]):
+                preview_text = note.n.fields[0][:50].replace("\n", " ")
+                if len(preview_text) == 50:
+                    preview_text += "..."
+                console.print(f"{i+1}. nid:{note.n.id} - {preview_text}")
+
+            if len(notes) > 5:
+                console.print(f"...and {len(notes) - 5} more notes")
+
+            console.print(
+                "\nUse --force-multiple to edit them all, or refine your query."
+            )
             return
 
         # Edit each note
+        edited_count = 0
         for i, note in enumerate(notes):
             if len(notes) > 1:
-                console.print(f"Editing note {i+1} of {len(notes)}")
+                console.print(
+                    f"\nEditing note {i+1} of {len(notes)} (nid: {note.n.id})"
+                )
+
+                # Show a brief preview of the note
+                preview_text = note.n.fields[0][:50].replace("\n", " ")
+                if len(preview_text) == 50:
+                    preview_text += "..."
+                console.print(f"Content preview: {preview_text}")
+                console.print(f"Tags: {', '.join(note.n.tags)}")
+
+                if not console.confirm("Edit this note?"):
+                    console.print("Skipping...")
+                    continue
 
             # Use the direct edit method (bypassing the review interface)
             note.edit()
+            edited_count += 1
+
+        # Summary message
+        if edited_count > 0:
+            console.print(
+                f"\n[green]Successfully edited {edited_count} note(s)[/green]"
+            )
+        else:
+            console.print("\n[yellow]No notes were edited[/yellow]")
+
 
 @main.command()
 def sync() -> None:

--- a/src/apyanki/cli.py
+++ b/src/apyanki/cli.py
@@ -486,21 +486,19 @@ def edit(query: str, force_multiple: bool) -> None:
 
         # Handle multiple matches
         if len(notes) > 1 and not force_multiple:
-            console.print(f"Query matched {len(notes)} notes.")
+            console.print(f"Query matched {len(notes)} notes. The first five:\n")
 
             # Show preview of the first 5 matching notes
-            console.print("\nFirst few matching notes:")
             for i, note in enumerate(notes[:5]):
                 preview_text = note.n.fields[0][:50].replace("\n", " ")
                 if len(preview_text) == 50:
                     preview_text += "..."
                 console.print(f"{i+1}. nid:{note.n.id} - {preview_text}")
 
-            if len(notes) > 5:
-                console.print(f"...and {len(notes) - 5} more notes")
-
             console.print(
-                "\nUse --force-multiple to edit them all, or refine your query."
+                "\nHints:\n"
+                "* Use 'apy edit --force-multiple' to edit all matches or refine your query so it only matches a single note.\n"
+                "* Use 'apy list QUERY' to view all matches."
             )
             return
 

--- a/src/apyanki/cli.py
+++ b/src/apyanki/cli.py
@@ -442,6 +442,63 @@ def review(query: str, check_markdown_consistency: bool, cmc_range: int) -> None
             else:
                 i += 1
 
+@main.command()
+@click.argument("query", nargs=-1, required=True)
+@click.option(
+    "--force-multiple",
+    "-f",
+    is_flag=True,
+    help="Allow editing multiple notes (will edit them one by one)",
+)
+def edit(query: str, force_multiple: bool) -> None:
+    """Edit notes that match QUERY directly.
+
+    This command allows direct editing of notes matching the provided query
+    without navigating through the interactive review interface.
+
+    If the query matches multiple notes, you'll be prompted to confirm
+    unless --force-multiple is specified.
+
+    Examples:
+
+    \b
+    # Edit a note by its card ID
+    apy edit cid:1740342619916
+
+    \b
+    # Edit a note by its note ID
+    apy edit nid:1234567890123
+
+    \b
+    # Edit a note containing specific text
+    apy edit "front:error"
+    """
+    query = " ".join(query)
+
+    with Anki(**cfg) as a:
+        notes = list(a.find_notes(query))
+
+        # Handle no matches
+        if not notes:
+            console.print(f"No notes found matching query: {query}")
+            return
+
+        # Handle multiple matches
+        if len(notes) > 1 and not force_multiple:
+            console.print(f"Query matched {len(notes)} notes.")
+            # for i, note in enumerate(notes[:5]):
+            # maybe we can show the first 5 matches?
+
+            console.print("Use --force-multiple to edit them all, or refine your query.")
+            return
+
+        # Edit each note
+        for i, note in enumerate(notes):
+            if len(notes) > 1:
+                console.print(f"Editing note {i+1} of {len(notes)}")
+
+            # Use the direct edit method (bypassing the review interface)
+            note.edit()
 
 @main.command()
 def sync() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9, <4"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -30,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "apyanki"
-version = "0.16.2"
+version = "0.16.3"
 source = { editable = "." }
 dependencies = [
     { name = "anki" },


### PR DESCRIPTION
This PR adds a new 'edit' command that allows users to directly edit notes matching a query without going through the interactive review interface. 

Features:
- Simple query syntax matching the standard Anki search format
- Safety check to prevent accidental editing of multiple notes
- Force multiple option (-f/--force-multiple) to edit multiple notes sequentially

The command provides a more efficient workflow for users who know exactly which notes they want to modify.

TODO: 
Consider implementing a feature to display the first few matches
when multiple notes are found.

- also added 'venv/' to gitignore
- related to #110