### PR TITLE
Remove upper bounds of dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,14 @@ classifiers = [
     "Environment :: Console",
 ]
 dependencies = [
-    "beautifulsoup4>=4.12.2,<5",
-    "click>=8.1.3,<9",
-    "markdown>=3.4.3,<4",
-    "readchar>=4.0.5,<5",
-    "markdownify>=0.11.6,<0.12",
+    "beautifulsoup4>=4.12.2",
+    "click>=8.1.3",
+    "markdown>=3.4.3",
+    "readchar>=4.0.5",
+    "markdownify>=0.11.6",
     "anki>=23.10",
     "html5lib~=1.1",
-    "rich>=13.7.1,<14",
+    "rich>=13.7.1",
 ]
 
 [project.urls]
@@ -31,13 +31,13 @@ apy = "apyanki.cli:main"
 
 [dependency-groups]
 dev = [
-    "pytest>=7.3.1,<8",
-    "pylint>=3.0.2,<4",
-    "bump2version>=1.0.1,<2",
-    "black>=24.3.0,<25",
-    "mypy>=1.3.0,<2",
-    "types-beautifulsoup4>=4.12.0.5,<5",
-    "types-markdown>=3.4.2.9,<4",
+    "pytest>=7.3.1",
+    "pylint>=3.0.2",
+    "bump2version>=1.0.1",
+    "black>=24.3.0",
+    "mypy>=1.3.0",
+    "types-beautifulsoup4>=4.12.0.5",
+    "types-markdown>=3.4.2.9",
 ]
 
 [build-system]
@@ -73,3 +73,4 @@ module = [
     "markdownify",
 ]
 ignore_missing_imports = true
+


### PR DESCRIPTION
I did not discuss this PR beforehand because it's simple and thought it's easier to just do a PR and discuss here instead of creating a separate issue beforehand.

I'm trying to add `apyanki` as a https://github.com/NixOS/nixpkgs package. They package the latest dependencies only to lower the maintenance burden. Upper bounds on dependencies break the package build because nixpkgs gets newer packages frequently.

The project builds and tests pass with this patch with the current unstable nixpkgs dependency versions.

Feel free to close if you don't like dependencies without upper bounds. Otherwise, let me know if you'd like me to do any modifications.