### PR TITLE
fix: make the -u option keep content before first '#' header

### DIFF
--- a/src/apyanki/anki.py
+++ b/src/apyanki/anki.py
@@ -598,6 +598,8 @@ class Anki:
 
         # Extract each note's section and check if it needs to be updated
         updated_content: list[str] = []
+        # Keep content before first '# Note'
+        updated_content.append(content[0 : note_positions[0]])
         for i in range(len(note_positions) - 1):
             start = note_positions[i]
             end = note_positions[i + 1]


### PR DESCRIPTION
Using the -u option with *add-from-file* or *update-from-file* deletes everything before the first '#' header.
I assume this is not really intended as it contradicts with the default values which are parsed by ``_parse_markdown_file`` before the first '#' header.

This change aims to fix this.